### PR TITLE
Fixed wrongly named `key` variable

### DIFF
--- a/src/ssh-client.html
+++ b/src/ssh-client.html
@@ -3,7 +3,7 @@
         category: 'input',
         defaults: {
             debug: {value:false},
-            ssh: { value: "" },
+            key: { value: "" },
             hostname: { value: "" },
             name: { value: "" },
         },
@@ -26,8 +26,8 @@
         <input type="checkbox" id="node-input-debug" placeholder="">
     </div>
     <div class="form-row">
-        <label for="node-input-ssh"><i class="fa fa-podcast"></i> Ssh</label>
-        <input type="text" id="node-input-ssh" placeholder="/home/user/.ssh/id_rsa">
+        <label for="node-input-key"><i class="fa fa-podcast"></i> Key</label>
+        <input type="text" id="node-input-key" placeholder="/home/user/.ssh/id_rsa">
     </div>
     <div class="form-row">
         <label for="node-input-hostname"><i class="fa fa-podcast"></i> Hostname</label>


### PR DESCRIPTION
The js file expect for a `key` variable name instead of `ssh`